### PR TITLE
Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/"
+    open-pull-requests-limit: 1
+    reviewers:
+      - "hopsor"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds dependabot to help with dependency updates.

So far I'll use it to update mix dependencies.