### PR TITLE
Feat:  Display winner when match is finished

### DIFF
--- a/lib/scrabblex_web/live/match_live/game_board_component.ex
+++ b/lib/scrabblex_web/live/match_live/game_board_component.ex
@@ -170,6 +170,21 @@ defmodule ScrabblexWeb.MatchLive.GameBoardComponent do
           </div>
         </div>
       </div>
+
+      <.modal :if={@winner} id="winner-modal" show>
+        <div class="flex flex-col items-center gap-y-2">
+          <div>
+            <.icon class="w-32 h-32 text-yellow-400" name="hero-trophy" />
+          </div>
+          <h1 class="font-semibold text-3xl">Winner</h1>
+          <p>
+            <.avatar user={@winner.user} />
+            <strong><%= @winner.user.name %></strong>
+          </p>
+          <p class="text-4xl"><%= @winner.score %></p>
+          <span>points</span>
+        </div>
+      </.modal>
     </div>
     """
   end
@@ -215,6 +230,7 @@ defmodule ScrabblexWeb.MatchLive.GameBoardComponent do
      |> assign(:match, match)
      |> assign(:events_topic, events_topic)
      |> assign(:player_on_turn, player_on_turn)
+     |> assign(:winner, detect_winner(match))
      |> assign(custom_assigns)}
   end
 
@@ -359,6 +375,12 @@ defmodule ScrabblexWeb.MatchLive.GameBoardComponent do
       {row, column, booster, Map.get(plays_matrix, {row, column}), true}
     end)
   end
+
+  defp detect_winner(%Match{status: "finished", players: players}) do
+    Enum.max_by(players, & &1.score)
+  end
+
+  defp detect_winner(_), do: nil
 
   # TODO: Consider using gettext
   defp submit_play_error_message({:error, :empty_play}) do

--- a/test/scrabblex_web/live/match_live_test.exs
+++ b/test/scrabblex_web/live/match_live_test.exs
@@ -493,6 +493,11 @@ defmodule ScrabblexWeb.MatchLiveTest do
              |> element("#play_log div.exchange")
              |> has_element?()
     end
+
+    # TODO: Implement when having better fixtures
+    @tag skip: "Pending to implement"
+    test "when the match is finished it shows a modal with winner's name and points" do
+    end
   end
 
   describe "Show / Wildcard Edition" do


### PR DESCRIPTION
This change adds a new modal that will pop up when the match status transition to "finished". The modal will show the winner by detecting the player with the max amount of points.

The actions bar will become hidden once the status is transitioned to "finished" preventing players from submitting more plays.