### PR TITLE
Feat: Google Analytics

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -128,4 +128,6 @@ if config_env() == :prod do
 
   config :scrabblex, Scrabblex.Accounts.User,
     admin_emails: System.get_env("ADMIN_EMAILS", "") |> String.split(",", trim: true)
+
+  config :scrabblex, :google_analytics, tag: System.get_env("GOOGLE_ANALYTICS_TAG")
 end

--- a/lib/scrabblex_web/components/layouts/root.html.heex
+++ b/lib/scrabblex_web/components/layouts/root.html.heex
@@ -10,6 +10,17 @@
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>
+    <%= if @google_analytics_tag do %>
+      <!-- Google tag (gtag.js) -->
+      <script async src={"https://www.googletagmanager.com/gtag/js?id=#{@google_analytics_tag}"}>
+      </script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '<%= @google_analytics_tag %>');
+      </script>
+    <% end %>
   </head>
   <body class="h-full">
     {@inner_content}

--- a/lib/scrabblex_web/google_analytics.ex
+++ b/lib/scrabblex_web/google_analytics.ex
@@ -1,0 +1,7 @@
+defmodule ScrabblexWeb.GoogleAnalytics do
+  import Plug.Conn
+
+  def set_google_analytics_tag(conn, _opts) do
+    assign(conn, :google_analytics_tag, Application.get_env(:scrabblex, :google_analytics)[:tag])
+  end
+end

--- a/lib/scrabblex_web/router.ex
+++ b/lib/scrabblex_web/router.ex
@@ -1,7 +1,7 @@
 defmodule ScrabblexWeb.Router do
   use ScrabblexWeb, :router
 
-  import ScrabblexWeb.UserAuth
+  import ScrabblexWeb.{GoogleAnalytics, UserAuth}
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -11,6 +11,7 @@ defmodule ScrabblexWeb.Router do
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :fetch_current_user
+    plug :set_google_analytics_tag
   end
 
   pipeline :api do


### PR DESCRIPTION
This PR adds Google Analytics.

The way I implemented it was by adding a new plug that looks into the configuration and puts the content in the assigns map.

If the tag isn't set it won't render any code. This will be helpful in dev env where we don't want to call analytics.