### PR TITLE
Chore: Deploy only after a successful CI run

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -2,11 +2,13 @@
 
 name: Fly Deploy
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [Elixir CI]
+    types: [completed]
+    branches: [main]
 jobs:
   deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Deploy app
     runs-on: ubuntu-latest
     concurrency: deploy-group    # optional: ensure only one action runs at a time


### PR DESCRIPTION
"On push" was replaced by "On workflow run" making the deployment dependent of the Elixir CI workflow.

The "completed" type triggers the deploy job even if the CI run was a failure. The only way to work around that limitation is by adding the `if` as suggested [here](https://github.com/orgs/community/discussions/26238#discussioncomment-3250901).
